### PR TITLE
Parameter value should be evaluated just once in inject()

### DIFF
--- a/src/main/scala/com/avast/syringe/config/perspective/SyringeModule.scala
+++ b/src/main/scala/com/avast/syringe/config/perspective/SyringeModule.scala
@@ -226,7 +226,7 @@ class SyringeModule extends Module {
               values ::=(propertyName, builder)
             })
           }
-          case _ => values ::=(propertyName, value)
+          case _ => values ::=(propertyName, v)
         }
         case _ => {
           values ::=(propertyName, v)


### PR DESCRIPTION
If e.g. a method call that returns a new instance of a Java class is passed to @ConfigProperty parameter, the method would be evaluated/called twice and two instances will be created by accident. This is acceptable for very simple state-less objects but not for objects that for example register JMX properties or connects to a remote system.

// Configuration.scala, createNewInstance() is called twice instead of once
aConfigBean.aParameter(createNewInstance(nameOfInstance))

// Generated Palette.scala calls inject() that evaluates the value twice
def aParameter(value: => Builder[_]): this.type = inject("aParameter", value)
